### PR TITLE
Query the GitHub API correctly

### DIFF
--- a/server/admin/message_prod.go
+++ b/server/admin/message_prod.go
@@ -26,20 +26,17 @@ var currentVersion version
 // NewVersionMessageGet checks if there is a new version of kjudge
 func NewVersionMessageGet() (string, error) {
 	if currentVersion.TagName == "" || time.Now().After(currentVersion.LastUpdate.Add(time.Hour)) {
-		response, err := http.Get("https://github.com/api/v1/repos/natsukagami/kjudge/releases?page=1&per_page=1")
+		response, err := http.Get("https://api.github.com/repos/natsukagami/kjudge/releases/latest")
 		if err != nil {
 			return "", errors.WithStack(err)
 		}
 		defer response.Body.Close()
-		var x []jsonRelease
+		var x jsonRelease
 		decode := json.NewDecoder(response.Body)
 		if err := decode.Decode(&x); err != nil {
 			return "", errors.WithStack(err)
 		}
-		if len(x) == 0 {
-			return "", errors.New("Found no relase")
-		}
-		currentVersion.TagName = x[0].TagName[1:]
+		currentVersion.TagName = x.TagName[1:]
 		currentVersion.LastUpdate = time.Now()
 	}
 	if kjudge.Version != currentVersion.TagName {


### PR DESCRIPTION
We `sed -i s/git.nkagami.me/github.com/` everything before, but Gitea and GitHub APIs are not the same. 

This will now correctly query GitHub for the latest release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/kjudge/8)
<!-- Reviewable:end -->
