### PR TITLE
Custom File Compilation

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -54,7 +54,7 @@ func New(filename string) (*DB, error) {
 // Rollback performs a rollback on the transaction.
 // Logs the error down on error.
 func Rollback(tx *sqlx.Tx) {
-	if err := tx.Rollback(); err != nil {
-		log.Println("[DB] Rollback error: ", err)
+	if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+		log.Printf("[DB] Rollback error: %+v", errors.WithStack(err))
 	}
 }

--- a/frontend/html/admin/file_inputs.html
+++ b/frontend/html/admin/file_inputs.html
@@ -17,6 +17,11 @@
                 <a title="Save file" class="text-btn hover:text-blue-600" href="{{$link}}">
                     [s]
                 </a>
+                {{ if .Compilable }}
+                <form class="inline" method="POST" action="{{$link}}/compile">
+                    <input type="submit" class="hover:text-green-600 text-btn" value="[x]" title="Compile file">
+                </form>
+                {{ end }}
                 <form class="inline require-confirm" method="POST" action="{{$link}}/delete">
                     <input type="submit" class="hover:text-red-600 text-btn" value="[d]" title="Delete file">
                 </form>

--- a/models/files.go
+++ b/models/files.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/natsukagami/kjudge/db"
@@ -33,6 +34,12 @@ func (f *File) Verify() error {
 		"Filename": verify.Names(f.Filename),
 		"Content":  verify.NotNull(f.Content),
 	})
+}
+
+// Compilable returns whether a file can be compiled.
+func (f *File) Compilable() bool {
+	_, err := LanguageByExt(filepath.Ext(f.Filename))
+	return err == nil
 }
 
 // WriteFiles writes the given files as brand new, overwritting the old ones.

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -62,6 +62,7 @@ func New(db *db.DB, unauthed *echo.Group) (*Group, error) {
 	// File
 	g.GET("/files/:id", grp.FileGet)
 	g.POST("/files/:id/delete", grp.FileDelete)
+	g.POST("/files/:id/compile", grp.FileCompile)
 	// Users
 	g.GET("/users", grp.UsersGet)
 	g.POST("/users", grp.UsersAdd)

--- a/server/admin/file.go
+++ b/server/admin/file.go
@@ -12,6 +12,7 @@ import (
 	"github.com/natsukagami/kjudge/db"
 	"github.com/natsukagami/kjudge/models"
 	"github.com/natsukagami/kjudge/server/httperr"
+	"github.com/natsukagami/kjudge/worker"
 	"github.com/pkg/errors"
 )
 
@@ -48,6 +49,52 @@ func (g *Group) FileDelete(c echo.Context) error {
 	}
 	if err := file.Delete(g.db); err != nil {
 		return err
+	}
+	return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/admin/problems/%d#files", file.ProblemID))
+}
+
+// FileCompile implements POST /admin/files/:id/compile
+func (g *Group) FileCompile(c echo.Context) error {
+	tx, err := g.db.Beginx()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer db.Rollback(tx)
+
+	file, err := getFile(tx, c)
+	if err != nil {
+		return err
+	}
+	if !file.Compilable() {
+		return httperr.BadRequestf("File is not a compilable file.")
+	}
+
+	// Collect all files
+	files, err := models.GetProblemFiles(tx, file.ProblemID)
+	if err != nil {
+		return err
+	}
+
+	output, err := worker.CustomCompile(file, files)
+	if err != nil {
+		return httperr.BadRequestf("%v", err)
+	}
+	output.ProblemID = file.ProblemID
+
+	// Check if there is a filename conflict
+	if f, err := models.GetFileWithName(tx, file.ProblemID, output.Filename); err == nil {
+		if err := f.Delete(tx); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+
+	if err := output.Write(tx); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.WithStack(err)
 	}
 	return c.Redirect(http.StatusSeeOther, fmt.Sprintf("/admin/problems/%d#files", file.ProblemID))
 }

--- a/worker/compile.go
+++ b/worker/compile.go
@@ -69,16 +69,19 @@ func Compile(c *CompileContext) (bool, error) {
 	log.Printf("[WORKER] Compiling submission %v\n", c.Sub.ID)
 
 	// Now, create a temporary directory.
-	dir := os.TempDir()
-	// Copy over all files and the source code.
-	if err := ioutil.WriteFile(filepath.Join(dir, action.Source), c.Sub.Source, 0666); err != nil {
+	dir, err := ioutil.TempDir("", "*")
+	if err != nil {
 		return false, errors.WithStack(err)
 	}
-	for _, file := range files {
-		if err := ioutil.WriteFile(filepath.Join(dir, file.Filename), file.Content, 0666); err != nil {
-			return false, errors.Wrapf(err, "copying file %s", file.Filename)
-		}
+	defer action.Cleanup(dir)
+
+	// Prepare source and files
+	action.Source.Content = c.Sub.Source
+	action.Files = files
+	if err := action.Prepare(dir); err != nil {
+		return false, err
 	}
+
 	// Perform compilation
 	result, messages := action.Perform(dir)
 	c.Sub.CompilerOutput = messages
@@ -102,17 +105,38 @@ func Compile(c *CompileContext) (bool, error) {
 // CompileAction is an action revolving writing the source into a file in "Source",
 // compile it with "Command" and taking the "Output" as the result.
 type CompileAction struct {
-	Source  string
-	Command []*exec.Cmd
-	Output  string
+	Source   *models.File
+	Files    []*models.File
+	Commands [][]string
+	Output   string
+}
+
+// Prepare prepares a temporary folder and copies all the content there.
+func (c *CompileAction) Prepare(dir string) error {
+	// Copy over all files and the source code.
+	if err := ioutil.WriteFile(filepath.Join(dir, c.Source.Filename), c.Source.Content, 0666); err != nil {
+		return errors.WithStack(err)
+	}
+	for _, file := range c.Files {
+		if err := ioutil.WriteFile(filepath.Join(dir, file.Filename), file.Content, 0666); err != nil {
+			return errors.Wrapf(err, "copying file %s", file.Filename)
+		}
+	}
+	return nil
+}
+
+// Cleanup performs clean-up on the prepared directory.
+func (c *CompileAction) Cleanup(dir string) {
+	_ = os.RemoveAll(dir)
 }
 
 // Perform performs the compile action on the given directory.
 // The directory MUST contain all files given by the Problem, PLUS the written "Source" file.
 func (c *CompileAction) Perform(cwd string) (succeeded bool, messages []byte) {
 	allOutputs := bytes.Buffer{}
-	for _, cmd := range c.Command {
-		allOutputs.WriteString(fmt.Sprintf("%s:\n", strings.Join(cmd.Args, " ")))
+	for _, command := range c.Commands {
+		allOutputs.WriteString(fmt.Sprintf("%s:\n", strings.Join(command, " ")))
+		cmd := exec.Command(command[0], command[1:]...)
 		// Set the cwd
 		cmd.Dir = cwd
 		// Run the command and collect outputs
@@ -185,9 +209,9 @@ func CompileBatch(l models.Language) (*CompileAction, string, error) {
 	}
 
 	return &CompileAction{
-		Source:  source,
-		Command: []*exec.Cmd{exec.Command("sh", batch)},
-		Output:  "code",
+		Source:   &models.File{Filename: source},
+		Commands: [][]string{{"sh", batch}},
+		Output:   "code",
 	}, batch, nil
 }
 
@@ -197,55 +221,55 @@ func CompileSingle(l models.Language) (*CompileAction, error) {
 	switch l {
 	case models.LanguageCpp:
 		return &CompileAction{
-			Source:  "code.cc",
-			Command: []*exec.Cmd{exec.Command("g++", "-std=c++17", "-O2", "-s", "-lm", "-DONLINE_JUDGE", "-DKJUDGE", "-o", "code", "code.cc")},
-			Output:  "code",
+			Source:   &models.File{Filename: "code.cc"},
+			Commands: [][]string{{"g++", "-std=c++17", "-O2", "-s", "-lm", "-DONLINE_JUDGE", "-DKJUDGE", "-o", "code", "code.cc"}},
+			Output:   "code",
 		}, nil
 	case models.LanguageGo:
 		return &CompileAction{
-			Source:  "code.go",
-			Command: []*exec.Cmd{exec.Command("go", "build", "-buildmode=exe", "-tags", "online_judge,kjudge", "-o", "code", "code.go")},
-			Output:  "code",
+			Source:   &models.File{Filename: "code.go"},
+			Commands: [][]string{{"go", "build", "-buildmode=exe", "-tags", "online_judge,kjudge", "-o", "code", "code.go"}},
+			Output:   "code",
 		}, nil
 	case models.LanguageJava:
 		return &CompileAction{
-			Source: "code.java",
-			Command: []*exec.Cmd{
-				exec.Command("javac", "-d", ".", "code.java"),
-				exec.Command("sh", "-c", "jar cf code *.class"),
-				exec.Command("sh", "-c", "rm *.class"),
+			Source: &models.File{Filename: "code.java"},
+			Commands: [][]string{
+				{"javac", "-d", ".", "code.java"},
+				{"sh", "-c", "jar cf code *.class"},
+				{"sh", "-c", "rm *.class"},
 			},
 			Output: "code",
 		}, nil
 	case models.LanguagePas:
 		return &CompileAction{
-			Source: "code.pas",
-			Command: []*exec.Cmd{
-				exec.Command("fpc", "-O3", "-dONLINE_JUDGE", "-dKJUDGE", "-ocode", "code.pas"),
+			Source: &models.File{Filename: "code.pas"},
+			Commands: [][]string{
+				{"fpc", "-O3", "-dONLINE_JUDGE", "-dKJUDGE", "-ocode", "code.pas"},
 			},
 			Output: "code",
 		}, nil
 	case models.LanguageRust:
 		return &CompileAction{
-			Source: "code.rs",
-			Command: []*exec.Cmd{
-				exec.Command("rustc", "-O", "--cfg", "online_judge", "--cfg", "kjudge", "-o", "code", "code.rs"),
+			Source: &models.File{Filename: "code.rs"},
+			Commands: [][]string{
+				{"rustc", "-O", "--cfg", "online_judge", "--cfg", "kjudge", "-o", "code", "code.rs"},
 			},
 			Output: "code",
 		}, nil
 	case models.LanguagePy2:
 		return &CompileAction{
-			Source: "code.py",
-			Command: []*exec.Cmd{
-				exec.Command("python2", "-m", "py_compile", "code.py"),
+			Source: &models.File{Filename: "code.py"},
+			Commands: [][]string{
+				{"python2", "-m", "py_compile", "code.py"},
 			},
 			Output: "code.pyc",
 		}, nil
 	case models.LanguagePy3:
 		return &CompileAction{
-			Source:  "code.py",
-			Command: []*exec.Cmd{exec.Command("python3", "-c", `import py_compile as m; m.compile("code.py", "code.pyc", doraise=True)`)},
-			Output:  "code.pyc",
+			Source:   &models.File{Filename: "code.py"},
+			Commands: [][]string{{"python3", "-c", `import py_compile as m; m.compile("code.py", "code.pyc", doraise=True)`}},
+			Output:   "code.pyc",
 		}, nil
 	default:
 		return nil, errors.Errorf("Unknown language: %v", l)

--- a/worker/custom_compile.go
+++ b/worker/custom_compile.go
@@ -29,6 +29,10 @@ func CustomCompile(source *models.File, files []*models.File) (*models.File, err
 	action.Source.Content = source.Content
 	action.Files = files
 
+	if err := action.Prepare(dir); err != nil {
+		return nil, err
+	}
+
 	result, message := action.Perform(dir)
 	if result {
 		output, err := ioutil.ReadFile(filepath.Join(dir, action.Output))

--- a/worker/custom_compile.go
+++ b/worker/custom_compile.go
@@ -1,0 +1,45 @@
+package worker
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/natsukagami/kjudge/models"
+	"github.com/pkg/errors"
+)
+
+// CustomCompile tries to compile a file from the given source file.
+func CustomCompile(source *models.File, files []*models.File) (*models.File, error) {
+	ext := filepath.Ext(source.Filename)
+	language, err := models.LanguageByExt(ext)
+	if err != nil {
+		return nil, err
+	}
+	// Find out the batch command
+	action, err := CompileSingle(language)
+	if err != nil {
+		return nil, err
+	}
+	// Perform compilation
+	dir, err := ioutil.TempDir("", "*")
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer action.Cleanup(dir)
+	action.Source.Content = source.Content
+	action.Files = files
+
+	result, message := action.Perform(dir)
+	if result {
+		output, err := ioutil.ReadFile(filepath.Join(dir, action.Output))
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return &models.File{
+			Filename: source.Filename[:len(source.Filename)-len(ext)],
+			Content:  output,
+		}, nil
+	} else {
+		return nil, errors.Errorf("Compilation failed with message:\n%s", string(message))
+	}
+}


### PR DESCRIPTION
Resolves #6.

New endpoint, POST `/admin/files/:id/compile`, allows the admin to run a single file compile command on any uploaded file.

This is useful, for example, to compile a `compare` binary. 

When running the compile command:
 - All headers uploaded are available
 - The output binary is named the same as the source file, without the extension (e.g. `compare.cc` compiles into `compare`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/kjudge/9)
<!-- Reviewable:end -->
