### PR TITLE
HTTPS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Build and Test
-on: [push, pull_request]
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
 
 jobs:
     build:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ kjudge.db.bak
 
 kjudge
 templates
+keys

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ models/*_generated.go
 # Database
 kjudge.db
 kjudge.db.bak
+kjudge.db-*
 
 kjudge
 templates

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ kjudge.db
 kjudge.db.bak
 kjudge.db-*
 
-kjudge
-templates
-keys
+/kjudge
+/templates
+/keys

--- a/cmd/kjudge/main.go
+++ b/cmd/kjudge/main.go
@@ -65,10 +65,10 @@ func main() {
 func startServer(server *server.Server) {
 	var err error
 	if *httpsDir == "" {
-    	// No HTTPS
+		// No HTTPS
 		err = server.Start(*port)
 	} else {
-    	// Start a HTTP server to host the root CA.
+		// Start a HTTP server to host the root CA.
 		if rootCAPort, ok := os.LookupEnv("ROOT_CA_PORT"); ok {
 			go func() {
 				if err := server.ServeHTTPRootCA(":"+rootCAPort, filepath.Join(*httpsDir, "root.pem")); err != nil {

--- a/cmd/kjudge/main.go
+++ b/cmd/kjudge/main.go
@@ -60,6 +60,13 @@ func main() {
 		if *httpsDir == "" {
 			err = server.Start(*port)
 		} else {
+			if rootCAPort, ok := os.LookupEnv("ROOT_CA_PORT"); ok {
+				go func() {
+					if err := server.ServeHTTPRootCA(":"+rootCAPort, filepath.Join(*httpsDir, "root.pem")); err != nil {
+						panic(err)
+					}
+				}()
+			}
 			err = server.StartWithSSL(*port, filepath.Join(*httpsDir, "kjudge.key"), filepath.Join(*httpsDir, "kjudge.crt"))
 		}
 		if err != nil {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,9 @@ RUN go generate && go build -tags production -o kjudge cmd/kjudge/main.go
 # Stage 4: Create awesome output image
 FROM ubuntu:bionic
 
-RUN apt-get update && apt-get install -y build-essential openjdk-8-jdk-headless fp-compiler python3.6 cgroup-lite python2.7 rustc golang libcap-dev
+RUN apt-get update && apt-get install -y \
+    build-essential openjdk-8-jdk-headless fp-compiler python3.6 cgroup-lite python2.7 rustc golang libcap-dev # Compilers  \
+    openssl # For HTTPS support
 
 COPY --from=isolate /isolate/ /isolate
 
@@ -43,11 +45,14 @@ WORKDIR /isolate
 RUN make install
 
 COPY --from=backend /kjudge/kjudge /usr/local/bin
+COPY --from=backend /kjudge/scripts /scripts
 
 RUN ln -s /usr/bin/python3.6 /usr/bin/python3 && ln -s /usr/bin/python2.7 /usr/bin/python2
 
-VOLUME ["/data"]
+VOLUME ["/data", "/certs"]
 
-EXPOSE 80
+EXPOSE 80 443
 
-CMD ["kjudge", "-port", "80", "-file", "/data/kjudge.db"]
+WORKDIR /
+ENTRYPOINT ["scripts/start_container.sh"]
+

--- a/docker/gcc-only.dockerfile
+++ b/docker/gcc-only.dockerfile
@@ -37,7 +37,7 @@ RUN go generate && go build -tags production -o kjudge cmd/kjudge/main.go
 # Stage 4: Create awesome output image
 FROM alpine:3
 
-RUN apk add --no-cache libcap make g++
+RUN apk add --no-cache libcap make g++ openssl bash
 
 COPY --from=isolate /isolate/ /isolate
 
@@ -45,9 +45,11 @@ WORKDIR /isolate
 RUN make install
 
 COPY --from=backend /kjudge/kjudge /usr/local/bin
+COPY --from=backend /kjudge/scripts /scripts
 
-VOLUME ["/data"]
+VOLUME ["/data", "/certs"]
 
-EXPOSE 80
+EXPOSE 80 443
 
-CMD ["kjudge", "-port", "80", "-file", "/data/kjudge.db"]
+WORKDIR /
+ENTRYPOINT ["scripts/start_container.sh"]

--- a/scripts/gen_cert.sh
+++ b/scripts/gen_cert.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+CERT_C=${CERT_C:-JP} # Country code
+CERT_ST=${CERT_ST:-Moonland} # State
+CERT_L=${CERT_L:-Kagamitown} # Locality
+CERT_O=${CERT_O:-"nki inc."} # Organization Name
+CERT_CN=${CERT_CN:-kjudge} # Common name
+CERT_EMAIL=${CERT_EMAIL:-not@nkagami.me} # Email address
+CERT_ALTNAMES=${CERT_ALTNAMES:-"IP:127.0.0.1,DNS:localhost"} # Alt hosts
+
+# All information
+CERT_SUBJ="/C=$CERT_C/ST=$CERT_ST/L=$CERT_L/O=$CERT_O/CN=$CERT_CN/emailAddress=$CERT_EMAIL"
+CERT_EXT="subjectAltName = $CERT_ALTNAMES"
+
+RSA_BITS=${RSA_BITS:-4096} # RSA bits
+
+# Paths
+ROOT_DIR=${1:-.}
+
+ROOT_KEY=$ROOT_DIR/root.key
+ROOT_CERT=$ROOT_DIR/root.pem
+
+KJUDGE_KEY=$ROOT_DIR/kjudge.key
+KJUDGE_CERT=$ROOT_DIR/kjudge.crt
+KJUDGE_CSR=$ROOT_DIR/kjudge.csr
+
+echo "Key info:"
+echo "- Country code = $CERT_C"
+echo "- State = $CERT_ST"
+echo "- Locality = $CERT_L"
+echo "- Organization Name = $CERT_O"
+echo "- Common name = $CERT_CN"
+echo "- Email address = $CERT_EMAIL"
+echo "- Alt hosts = $CERT_ALTNAMES"
+echo
+
+echo "Generating root private key to $ROOT_KEY"
+openssl genrsa -out $ROOT_KEY $RSA_BITS 
+
+echo "Generating a root certificate authority to $ROOT_CERT"
+openssl req -x509 -new -key $ROOT_KEY -days 1285 -out $ROOT_CERT \
+    -subj "$CERT_SUBJ"
+
+echo "Generating a sub-key for kjudge to $KJUDGE_KEY"
+openssl genrsa -out $KJUDGE_KEY $RSA_BITS 
+
+echo "Generating a certificate signing request to $KJUDGE_CSR"
+openssl req -new -key $KJUDGE_KEY -out $KJUDGE_CSR \
+    -subj "$CERT_SUBJ" \
+    -addext "$CERT_EXT" 
+
+echo "Generating a certificate signature to $KJUDGE_CERT"
+echo "[v3_ca]\n$CERT_EXT" | openssl x509 -req -days 730 \
+    -in $KJUDGE_CSR \
+    -CA $ROOT_CERT -CAkey $ROOT_KEY -CAcreateserial \
+    -extensions v3_ca -extfile - \
+    -out $KJUDGE_CERT 
+
+echo "Certificate generation complete."
+echo "Please keep $ROOT_KEY and $KJUDGE_KEY secret, while distributing"\
+    "$ROOT_CERT as the certificate authority."

--- a/scripts/gen_cert.sh
+++ b/scripts/gen_cert.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    echo "gen_certs.sh [target-dir=.] [-h|--help]
+    cert generation environment variables:
+        - RSA_BITS      [4096]                         Strength of the RSA key.
+        - CERT_C        [JP]                           Certificate country code
+        - CERT_ST       [Moonland]                     Certificate State
+        - CERT_L        [Kagamitown]                   Certificate Locality
+        - CERT_O        [nki inc.]                     Certificate Organization Name
+        - CERT_CN       [kjudge]                       Certificate Common name
+        - CERT_EMAIL    [not@nkagami.me]               Certificate Email address
+        - CERT_ALTNAMES [IP:127.0.0.1,DNS:localhost]   A list of hosts that kjudge will be listening on, either by IP (as 'IP:1.2.3.4') or DNS (as 'DNS:google.com'), separated by ','"
+    exit 0
+fi
+
 CERT_C=${CERT_C:-JP} # Country code
 CERT_ST=${CERT_ST:-Moonland} # State
 CERT_L=${CERT_L:-Kagamitown} # Locality

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+useHTTPS=false
+
+showUsage() {
+    echo "$(basename "$0")
+
+    environment variable options:
+        HTTPS=preconfigured    Turn on HTTPS, using /certs/kjudge.pem and /certs/kjudge.key as certificate and private key.
+        HTTPS=generate         Turn on HTTPS, generating keys from scratch (saving them to /certs).
+
+    cert generation environment variables:
+        - RSA_BITS      [4096]                         Strength of the RSA key.
+        - CERT_C        [JP]                           Certificate country code
+        - CERT_ST       [Moonland]                     Certificate State
+        - CERT_L        [Kagamitown]                   Certificate Locality
+        - CERT_O        [nki inc.]                     Certificate Organization Name
+        - CERT_CN       [kjudge]                       Certificate Common name
+        - CERT_EMAIL    [not@nkagami.me]               Certificate Email address
+        - CERT_ALTNAMES [IP:127.0.0.1,DNS:localhost]   A list of hosts that kjudge will be listening on, either by IP (as 'IP:1.2.3.4') or DNS (as 'DNS:google.com'), separated by ','"
+}
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    showUsage
+    exit 0
+fi
+
+case $HTTPS in
+    preconfigured)
+    if [ ! -d "/certs" ]; then
+        >&2 echo "Please mount the directory containing certs to /certs"
+        exit 1
+    fi
+    useHTTPS=true
+    ;;
+    generate)
+    useHTTPS=true
+    export ROOT_CA_PORT=80 # Enable root certificate authority endpoint
+    mkdir -p /certs
+    scripts/gen_cert.sh /certs
+    ;;
+esac
+
+if [ "$useHTTPS" = true ]; then
+    kjudge -port 443 -file /data/kjudge.db -https /certs
+else
+    kjudge -port 80 -file /data/kjudge.db
+fi
+

--- a/server/root_ca.go
+++ b/server/root_ca.go
@@ -17,16 +17,6 @@ func (s *Server) ServeHTTPRootCA(address, rootCA string) error {
 	} else if stat.IsDir() {
 		return errors.Errorf("cannot use rootCA: %s is a directory", rootCA)
 	}
-	// server := http.Server{
-	// 	Addr: address,
-	// 	Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	// 		if r.Method != "GET" || r.URL.EscapedPath() != "/ca" {
-	// 			w.WriteHeader(404)
-	// 			return
-	// 		}
-	// 		http.ServeFile(w, r, rootCA)
-	// 	}),
-	// }
 	server := echo.New()
 	server.GET("/ca", func(c echo.Context) error {
 		return c.Attachment(rootCA, "root.pem")
@@ -34,6 +24,6 @@ func (s *Server) ServeHTTPRootCA(address, rootCA string) error {
 	server.HideBanner = true
 	server.HidePort = true
 	defer func() { _ = server.Shutdown(context.Background()) }()
-	log.Printf("Root certificate is being served on '%s'", address)
+	log.Printf("Root certificate is being served on '%s', obtain the Root CA on /ca", address)
 	return errors.WithStack(server.Start(address))
 }

--- a/server/root_ca.go
+++ b/server/root_ca.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+)
+
+// ServeHTTPRootCA starts a HTTP server running on `address`
+// serving the root CA from "/ca". It rejects all other requests.
+func (s *Server) ServeHTTPRootCA(address, rootCA string) error {
+	if stat, err := os.Stat(rootCA); err != nil {
+		return errors.WithStack(err)
+	} else if stat.IsDir() {
+		return errors.Errorf("cannot use rootCA: %s is a directory", rootCA)
+	}
+	// server := http.Server{
+	// 	Addr: address,
+	// 	Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// 		if r.Method != "GET" || r.URL.EscapedPath() != "/ca" {
+	// 			w.WriteHeader(404)
+	// 			return
+	// 		}
+	// 		http.ServeFile(w, r, rootCA)
+	// 	}),
+	// }
+	server := echo.New()
+	server.GET("/ca", func(c echo.Context) error {
+		return c.Attachment(rootCA, "root.pem")
+	})
+	server.HideBanner = true
+	server.HidePort = true
+	defer func() { _ = server.Shutdown(context.Background()) }()
+	log.Printf("Root certificate is being served on '%s'", address)
+	return errors.WithStack(server.Start(address))
+}

--- a/server/server.go
+++ b/server/server.go
@@ -125,6 +125,11 @@ func (s *Server) Start(port int) error {
 	return s.echo.Start(fmt.Sprintf(":%d", port))
 }
 
+// StartWithSSL starts the server with a given private key and certificate file paths.
+func (s *Server) StartWithSSL(port int, privateKey, cert string) error {
+	return s.echo.StartTLS(fmt.Sprintf(":%d", port), cert, privateKey)
+}
+
 // StartWithTLS starts the server, also tries to get a cert from LetsEncrypt.
 func (s *Server) StartWithTLS(address string) error {
 	return s.echo.StartAutoTLS(address)


### PR DESCRIPTION
Resolves #33

**Brief Description of the Changes**
- [x] Add HTTPS support by self-signed certificates
    - `-https dir` option uses `dir/kjudge.key` and `dir/kjudge.crt` as the HTTPS private key and certificate.
    - `ROOT_CA_PORT` environment variable serves the root CA (in `dir/root.pem`) on `/ca` by HTTP.
- [x] Helper script for generating root CAs and certificates (`scripts/gen_cert.sh [target-dir]`).
    - [x] Documentation for this script.
- [x] Docker support for passing and storing generated certificates in `/certs`.
- [x] Documentation ([a Wiki page](https://github.com/natsukagami/kjudge/wiki/Setting-up-HTTPS)) for setting up HTTPS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/kjudge/37)
<!-- Reviewable:end -->
