### PR TITLE
Tweaks to reduce memory usage on large tests

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -3,7 +3,7 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	log.Println("Now reading SQL commands from the standard input.")
-	sql, err := ioutil.ReadAll(os.Stdin)
+	sql, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatalf("%+v", errors.WithStack(err))
 	}

--- a/models/test_groups.go
+++ b/models/test_groups.go
@@ -1,9 +1,6 @@
 package models
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/natsukagami/kjudge/db"
 	"github.com/natsukagami/kjudge/models/verify"

--- a/server/admin/problem.go
+++ b/server/admin/problem.go
@@ -3,7 +3,7 @@ package admin
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -189,7 +189,7 @@ func (g *Group) ProblemAddFile(c echo.Context) error {
 			return errors.Wrapf(err, "file %s", file.Filename)
 		}
 		defer r.Close()
-		content, err := ioutil.ReadAll(r)
+		content, err := io.ReadAll(r)
 		if err != nil {
 			return errors.Wrapf(err, "file %s", file.Filename)
 		}

--- a/server/admin/test_groups.go
+++ b/server/admin/test_groups.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"strconv"
@@ -202,7 +202,7 @@ func readFromForm(name string, form *multipart.Form) ([]byte, error) {
 		return nil, errors.WithStack(err)
 	}
 	defer f.Close()
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -292,7 +292,7 @@ func readZip(f *zip.File) ([]byte, error) {
 		return nil, errors.WithStack(err)
 	}
 	defer reader.Close()
-	res, err := ioutil.ReadAll(reader)
+	res, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/server/contests/problem.go
+++ b/server/contests/problem.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -154,7 +154,7 @@ func (g *Group) SubmitPost(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 	defer fileContent.Close()
-	source, err := ioutil.ReadAll(fileContent)
+	source, err := io.ReadAll(fileContent)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -107,7 +106,7 @@ func (s *Server) HandleError(err error, c echo.Context) {
 
 		errStr := fmt.Sprintf("An unexpected error has occured: %v\n", err)
 		path := filepath.Join(os.TempDir(), fmt.Sprintf("kjudge-%v.txt", time.Now().Format(time.RFC3339)))
-		if err := ioutil.WriteFile(path, []byte(fmt.Sprintf("%+v", errors.WithStack(err))), 0644); err != nil {
+		if err := os.WriteFile(path, []byte(fmt.Sprintf("%+v", errors.WithStack(err))), 0644); err != nil {
 			errStr += fmt.Sprintf("Cannot log the error down to file: %v", err)
 		} else {
 			errStr += fmt.Sprintf(`The error has been logged down to file '%s'.

--- a/worker/compile.go
+++ b/worker/compile.go
@@ -11,7 +11,6 @@ package worker
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -69,7 +68,7 @@ func Compile(c *CompileContext) (bool, error) {
 	log.Printf("[WORKER] Compiling submission %v\n", c.Sub.ID)
 
 	// Now, create a temporary directory.
-	dir, err := ioutil.TempDir("", "*")
+	dir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
@@ -88,7 +87,7 @@ func Compile(c *CompileContext) (bool, error) {
 
 	if result {
 		// Success!
-		output, err := ioutil.ReadFile(filepath.Join(dir, action.Output))
+		output, err := os.ReadFile(filepath.Join(dir, action.Output))
 		if err != nil {
 			return false, errors.WithStack(err)
 		}
@@ -114,11 +113,11 @@ type CompileAction struct {
 // Prepare prepares a temporary folder and copies all the content there.
 func (c *CompileAction) Prepare(dir string) error {
 	// Copy over all files and the source code.
-	if err := ioutil.WriteFile(filepath.Join(dir, c.Source.Filename), c.Source.Content, 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, c.Source.Filename), c.Source.Content, 0666); err != nil {
 		return errors.WithStack(err)
 	}
 	for _, file := range c.Files {
-		if err := ioutil.WriteFile(filepath.Join(dir, file.Filename), file.Content, 0666); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, file.Filename), file.Content, 0666); err != nil {
 			return errors.Wrapf(err, "copying file %s", file.Filename)
 		}
 	}

--- a/worker/custom_compile.go
+++ b/worker/custom_compile.go
@@ -1,7 +1,7 @@
 package worker
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/natsukagami/kjudge/models"
@@ -21,7 +21,7 @@ func CustomCompile(source *models.File, files []*models.File) (*models.File, err
 		return nil, err
 	}
 	// Perform compilation
-	dir, err := ioutil.TempDir("", "*")
+	dir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -35,7 +35,7 @@ func CustomCompile(source *models.File, files []*models.File) (*models.File, err
 
 	result, message := action.Perform(dir)
 	if result {
-		output, err := ioutil.ReadFile(filepath.Join(dir, action.Output))
+		output, err := os.ReadFile(filepath.Join(dir, action.Output))
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/worker/sandbox.go
+++ b/worker/sandbox.go
@@ -1,7 +1,7 @@
 package worker
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -46,13 +46,13 @@ type SandboxOutput struct {
 func (input *SandboxInput) CopyTo(cwd string) error {
 	// Copy all the files into "cwd"
 	for name, file := range input.Files {
-		if err := ioutil.WriteFile(filepath.Join(cwd, name), file, 0666); err != nil {
+		if err := os.WriteFile(filepath.Join(cwd, name), file, 0666); err != nil {
 			return errors.Wrapf(err, "writing file %s", name)
 		}
 	}
 	// Copy and set chmod the "code" file
 	if input.CompiledSource != nil {
-		if err := ioutil.WriteFile(filepath.Join(cwd, "code"), input.CompiledSource, 0777); err != nil {
+		if err := os.WriteFile(filepath.Join(cwd, "code"), input.CompiledSource, 0777); err != nil {
 			return errors.WithStack(err)
 		}
 	}

--- a/worker/score.go
+++ b/worker/score.go
@@ -32,7 +32,7 @@ func Score(s *ScoreContext) error {
 	if err != nil {
 		return err
 	}
-	tests, err := models.GetProblemTests(s.DB, s.Problem.ID)
+	tests, err := models.GetProblemTestsMeta(s.DB, s.Problem.ID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Brief Description of the Changes**
- Fetch only test meta on scoring
- Delay processing of multiple tests to save memory

