### PR TITLE
Prevent scoreboard from being fetched as CSV when hidden

### DIFF
--- a/server/httperr/error.go
+++ b/server/httperr/error.go
@@ -23,7 +23,7 @@ func BadRequestf(format string, args ...interface{}) error {
 	return Newf(http.StatusBadRequest, format, args...)
 }
 
-// Unauthorizedf creates an HTTP error with "bad request" code and a message.
+// Unauthorizedf creates an HTTP error with "unauthorized" code and a message.
 func Unauthorizedf(format string, args ...interface{}) error {
 	return Newf(http.StatusUnauthorized, format, args...)
 }

--- a/server/httperr/error.go
+++ b/server/httperr/error.go
@@ -23,6 +23,11 @@ func BadRequestf(format string, args ...interface{}) error {
 	return Newf(http.StatusBadRequest, format, args...)
 }
 
+// Unauthorizedf creates an HTTP error with "bad request" code and a message.
+func Unauthorizedf(format string, args ...interface{}) error {
+	return Newf(http.StatusUnauthorized, format, args...)
+}
+
 // BindFail creates an HTTP error with "bind fail" message.
 func BindFail(err error) error {
 	return BadRequestf("cannot bind form: %v", err)


### PR DESCRIPTION
Run `.Show` on those two endpoints basically.
