### PR TITLE
Use `query` tag for GET query parameters instead of `form`

### DIFF
--- a/server/admin/batch_users.go
+++ b/server/admin/batch_users.go
@@ -45,9 +45,9 @@ func (g *Group) BatchUsersEmptyGet(c echo.Context) error {
 
 // BatchUsersGenerateForm is the form for generating a CSV users file.
 type BatchUsersGenerateForm struct {
-	Prefix string `form:"prefix"`
-	Count  int    `form:"count"`
-	Offset int    `form:"offset"`
+	Prefix string `query:"prefix"`
+	Count  int    `query:"count"`
+	Offset int    `query:"offset"`
 }
 
 // Verify verifies the content of the form.


### PR DESCRIPTION
New echo version doesn't seem to parse `form`-tagged fields out of
URL query parameters anymore.

Pending #89 for some testing :D
