### PR TITLE
Fix file access for embedded files on windows

### DIFF
--- a/db/migrations.go
+++ b/db/migrations.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"io/fs"
 	"log"
-	"path/filepath"
+	"path"
 	"regexp"
 	"sort"
 
@@ -44,7 +44,7 @@ func (db *DB) migrate() error {
 
 	// Do migrations one by one
 	for _, name := range versions {
-		sqlFile := filepath.Join(assetsSql, name+".sql")
+		sqlFile := path.Join(assetsSql, name+".sql")
 		file, err := fs.ReadFile(embed.Content, sqlFile)
 		if err != nil {
 			return errors.Wrapf(err, "File %s", sqlFile)

--- a/embed/doc.go
+++ b/embed/doc.go
@@ -1,0 +1,5 @@
+// Package embed puts all files in embed/assets and embed/templates
+// into the executable.
+// While the embed file system is cross-platform, it always exposes a
+// '/'-delimited file system.
+package embed

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/pkg/errors v0.9.1
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
-	golang.org/x/net v0.7.0
+	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/text v0.7.0
 	golang.org/x/tools v0.1.12
 	google.golang.org/appengine v1.6.5 // indirect

--- a/scripts/windows/production_test.ps1
+++ b/scripts/windows/production_test.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop"
+Remove-Item kjudge.db*
+
+& "scripts\windows\production_build.ps1"
+
+Invoke-Expression ".\kjudge $args"
+
+# Run pwsh -c scripts/windows/production_test.ps1 --sandbox=raw to test this script

--- a/scripts/windows/production_test.ps1
+++ b/scripts/windows/production_test.ps1
@@ -5,4 +5,4 @@ Remove-Item kjudge.db*
 
 Invoke-Expression ".\kjudge $args"
 
-# Run pwsh -c scripts/windows/production_test.ps1 --sandbox=raw to test this script
+# pwsh -c scripts/windows/production_test.ps1 --sandbox=raw to run this test script


### PR DESCRIPTION
Windows uses '\\' as path separator, while Linux uses '/'. However, Go's embed file system uses '/' on all platforms.

To reproduce this, delete all leftover database files then run the Kjudge executable to trigger db migration files access.